### PR TITLE
Making possible send payments without shipping address

### DIFF
--- a/src/PayU/Entity/Transaction/Order/OrderEntity.php
+++ b/src/PayU/Entity/Transaction/Order/OrderEntity.php
@@ -27,7 +27,6 @@ class OrderEntity implements EntityInterface
      */
     public function __construct()
     {
-        $this->shippingAddress  = new ShippingAddressEntity();
         $this->additionalValues = new AdditionalValuesEntity();
         $this->buyer            = new BuyerEntity();
     }
@@ -224,6 +223,9 @@ class OrderEntity implements EntityInterface
      */
     public function getShippingAddress()
     {
+        if(is_null($this->shippingAddress)) {
+            $this->shippingAddress = new ShippingAddressEntity();
+        }
         return $this->shippingAddress;
     }
 
@@ -291,16 +293,23 @@ class OrderEntity implements EntityInterface
      */
     public function toArray()
     {
-        return array(
+        $return =  array(
             'accountId'        => $this->accountId,
             'referenceCode'    => $this->referenceCode,
             'description'      => $this->description,
             'language'         => $this->language,
             'notifyUrl'        => $this->notifyUrl,
             'signature'        => $this->signature,
-            'shippingAddress'  => $this->shippingAddress->toArray(),
             'buyer'            => $this->buyer->toArray(),
             'additionalValues' => $this->additionalValues->toArray(),
         );
+        if (!$this->getShippingAddress()->isEmpty()) {
+            $return = array_merge(
+                $return,
+                array('shippingAddress' => $this->shippingAddress->toArray())
+            );
+        }
+
+        return $return;
     }
 }

--- a/src/PayU/Entity/Transaction/ShippingAddressEntity.php
+++ b/src/PayU/Entity/Transaction/ShippingAddressEntity.php
@@ -197,6 +197,21 @@ class ShippingAddressEntity implements EntityInterface
         return (string)$this->phone;
     }
 
+
+    /**
+     * Returns if object is empty
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        foreach (get_object_vars($this) as $property) {
+            if($property !== null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
      * Generate arry order.
      * @return array

--- a/src/PayU/Payment/PaymentApi.php
+++ b/src/PayU/Payment/PaymentApi.php
@@ -192,30 +192,33 @@ class PaymentApi extends ApiAbstract
         $xmlOrder->addChild('signature', $signature);
         //Order signature.
 
-        $shippingAddress    = $order->getShippingAddress();
-        $xmlShippingAddress = $xmlOrder->addChild('shippingAddress');
-        $xmlShippingAddress->addChild('street1', $shippingAddress->getStreet1());
-        $xmlShippingAddress->addChild('street2', $shippingAddress->getStreet2());
-        $xmlShippingAddress->addChild('city', $shippingAddress->getCity());
-        $xmlShippingAddress->addChild('state', $shippingAddress->getState());
-        $xmlShippingAddress->addChild('country', $shippingAddress->getCountry());
-        $xmlShippingAddress->addChild('postalCode', $shippingAddress->getPostalCode());
-        $xmlShippingAddress->addChild('phone', $shippingAddress->getPhone());
-
         $buyer    = $order->getBuyer();
         $xmlBuyer = $xmlOrder->addChild('buyer');
         $xmlBuyer->addChild('fullName', $buyer->getFullName());
         $xmlBuyer->addChild('emailAddress', $buyer->getEmailAddress());
         $xmlBuyer->addChild('dniNumber', $buyer->getDniNumber());
 
-        $xmlBuyerShippingAddress = $xmlBuyer->addChild('shippingAddress');
-        $xmlBuyerShippingAddress->addChild('street1', $shippingAddress->getStreet1());
-        $xmlBuyerShippingAddress->addChild('street2', $shippingAddress->getStreet2());
-        $xmlBuyerShippingAddress->addChild('city', $shippingAddress->getCity());
-        $xmlBuyerShippingAddress->addChild('state', $shippingAddress->getState());
-        $xmlBuyerShippingAddress->addChild('country', $shippingAddress->getCountry());
-        $xmlBuyerShippingAddress->addChild('postalCode', $shippingAddress->getPostalCode());
-        $xmlBuyerShippingAddress->addChild('phone', $shippingAddress->getPhone());
+        $shippingAddress = $order->getShippingAddress();
+
+        if (!$shippingAddress->isEmpty()) {
+            $xmlShippingAddress = $xmlOrder->addChild('shippingAddress');
+            $xmlShippingAddress->addChild('street1', $shippingAddress->getStreet1());
+            $xmlShippingAddress->addChild('street2', $shippingAddress->getStreet2());
+            $xmlShippingAddress->addChild('city', $shippingAddress->getCity());
+            $xmlShippingAddress->addChild('state', $shippingAddress->getState());
+            $xmlShippingAddress->addChild('country', $shippingAddress->getCountry());
+            $xmlShippingAddress->addChild('postalCode', $shippingAddress->getPostalCode());
+            $xmlShippingAddress->addChild('phone', $shippingAddress->getPhone());
+
+            $xmlBuyerShippingAddress = $xmlBuyer->addChild('shippingAddress');
+            $xmlBuyerShippingAddress->addChild('street1', $shippingAddress->getStreet1());
+            $xmlBuyerShippingAddress->addChild('street2', $shippingAddress->getStreet2());
+            $xmlBuyerShippingAddress->addChild('city', $shippingAddress->getCity());
+            $xmlBuyerShippingAddress->addChild('state', $shippingAddress->getState());
+            $xmlBuyerShippingAddress->addChild('country', $shippingAddress->getCountry());
+            $xmlBuyerShippingAddress->addChild('postalCode', $shippingAddress->getPostalCode());
+            $xmlBuyerShippingAddress->addChild('phone', $shippingAddress->getPhone());
+        }
 
         $additionalValues    = $order->getAdditionalValues()->toArray();
         $xmlAdditionalValues = $xmlOrder->addChild('additionalValues');

--- a/tests/PayU/Entity/Transaction/ShippingAddressEntityTest.php
+++ b/tests/PayU/Entity/Transaction/ShippingAddressEntityTest.php
@@ -35,6 +35,11 @@ class ShippingAddressEntityTest extends \PHPUnit_Framework_TestCase
     	unset($this->object);
     }
 
+    public function testIsEmptyWithEmptyObjectShouldReturnTrue()
+    {
+        $this->assertTrue($this->object->isEmpty());
+    }
+
 	/**
 	 * @see ShippingAddressEntity::getStreet1()
 	 */
@@ -221,5 +226,11 @@ class ShippingAddressEntityTest extends \PHPUnit_Framework_TestCase
 
     	$rs = $this->object->toArray();
     	$this->assertSame($entity, $rs);
+    }
+
+    public function testIsEmptyWithNotEmptyObjectShouldReturnFalse()
+    {
+        $this->object->setCity('Test');
+        $this->assertFalse($this->object->isEmpty());
     }
 }


### PR DESCRIPTION
Payments without shipping address cannot be processed in current code.
This fix verify if shipping address is empty, if so shipping information are not sent to PayU.
