### PR TITLE
Adding VOID and CAPTURE methods

### DIFF
--- a/src/PayU/Api/ApiAbstract.php
+++ b/src/PayU/Api/ApiAbstract.php
@@ -27,6 +27,11 @@ abstract class ApiAbstract implements ApiInterface
     protected $xmlRequest = null;
 
     /**
+     * @var SimpleXMLElement
+     */
+    protected $lastXmlRequest = null;
+
+    /**
      * Response raw from the PayU request.
      * @var string
      */
@@ -66,6 +71,26 @@ abstract class ApiAbstract implements ApiInterface
     }
 
     /**
+     * @return SimpleXMLElement
+     */
+    public function getLastXmlRequest()
+    {
+        return $this->lastXmlRequest;
+    }
+
+    /**
+     * @param SimpleXMLElement $lastXmlRequest
+     * @return $this
+     */
+    protected function setLastXmlRequest($lastXmlRequest)
+    {
+        $this->lastXmlRequest = $lastXmlRequest;
+        return $this;
+    }
+
+
+
+    /**
      * Reset request object.
      * @return ApiAbstract
      */
@@ -81,7 +106,7 @@ abstract class ApiAbstract implements ApiInterface
      */
     public function getXmlRawObject()
     {
-        return $this->xmlRequest;
+        return $this->getLastXmlRequest();
     }
 
     /**
@@ -90,7 +115,7 @@ abstract class ApiAbstract implements ApiInterface
      */
     public function getXmlRawString()
     {
-        return $this->xmlRequest->asXML();
+        return $this->getLastXmlRequest()->asXML();
     }
 
     /**

--- a/src/PayU/Payment/PaymentTypes.php
+++ b/src/PayU/Payment/PaymentTypes.php
@@ -19,4 +19,5 @@ class PaymentTypes
     const AUTHORIZATION             = 'AUTHORIZATION';
     const CAPTURE                   = 'CAPTURE';
     const REFUND                    = 'REFUND';
+    const VOID                      = 'VOID';
 }

--- a/tests/PayU/Payment/PaymentApiTest.php
+++ b/tests/PayU/Payment/PaymentApiTest.php
@@ -238,7 +238,7 @@ class PaymentApiTest extends \PHPUnit_Framework_TestCase
     	$creditCard->setNumber('4111111111111111')
     	           ->setSecurityCode(rand(1,9) . rand(1,9) . rand(1,9))
     	           ->setExpirationDate(rand(2015,2020) . '/' . rand(10,12))
-    	           ->setName('person name ' . rand(1,9) . rand(1,9) . rand(1,9));
+                   ->setName('person name ' . rand(1,9) . rand(1,9) . rand(1,9));
     	//Credit card.
 
     	//Payer.
@@ -256,21 +256,21 @@ class PaymentApiTest extends \PHPUnit_Framework_TestCase
      * Verify transaction response.
      * @param stdClass $response
      */
-    private function _testTransactionResponse($rs)
+    private function _testTransactionResponse($response)
     {
-    	$this->assertInstanceOf('\stdClass', $rs);
-    	$this->assertTrue(isset($rs->code));
-    	$this->assertEquals(0, strlen($rs->error));
+    	$this->assertInstanceOf('\stdClass', $response);
+    	$this->assertTrue(isset($response->code));
+    	$this->assertEquals(0, strlen($response->error));
 
-    	$this->assertTrue(isset($rs->transactionResponse));
-    	$this->assertInstanceOf('\stdClass', $rs->transactionResponse);
+    	$this->assertTrue(isset($response->transactionResponse));
+    	$this->assertInstanceOf('\stdClass', $response->transactionResponse);
 
-    	$transaction = $rs->transactionResponse;
+    	$transaction = $response->transactionResponse;
 
-    	$this->assertTrue(isset($rs->transactionResponse->orderId));
-    	$this->assertTrue(isset($rs->transactionResponse->transactionId));
-    	$this->assertTrue(isset($rs->transactionResponse->state));
-    	$this->assertTrue(isset($rs->transactionResponse->responseCode));
+    	$this->assertTrue(isset($response->transactionResponse->orderId));
+    	$this->assertTrue(isset($response->transactionResponse->transactionId));
+    	$this->assertTrue(isset($response->transactionResponse->state));
+    	$this->assertTrue(isset($response->transactionResponse->responseCode));
 
     	$this->assertEquals(0, strlen($transaction->paymentNetworkResponseCode));
     	$this->assertEquals(0, strlen($transaction->paymentNetworkResponseErrorMessage));
@@ -288,6 +288,8 @@ class PaymentApiTest extends \PHPUnit_Framework_TestCase
     /**
      * @see PaymentApi::authorize()
      * @dataProvider providerMockTransaction
+     *
+     * @param \PayU\Entity\Transaction\TransactionEntity $transaction
      */
     public function testAuthorize($transaction)
     {
@@ -298,6 +300,8 @@ class PaymentApiTest extends \PHPUnit_Framework_TestCase
     /**
      * @see PaymentApi::authorizeAndCapture()
      * @dataProvider providerMockTransaction
+     *
+     * @param \PayU\Entity\Transaction\TransactionEntity $transaction
      */
     public function testAuthorizeAndCapture($transaction)
     {
@@ -307,24 +311,40 @@ class PaymentApiTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @see PaymentApi::capture()
+     * @dataProvider providerMockTransaction
+     *
+     * @param \PayU\Entity\Transaction\TransactionEntity $transaction
      */
-    public function testCapture()
+    public function testCapture($transaction)
     {
-    	$this->markTestIncomplete();
+        $this->markTestIncomplete(
+            "Needs a real transaction. Actually provider returns only denied transactions."
+        );
+
+        $mock = $this->object->authorize($transaction);
+        $rs   = $this->object->capture(
+            $mock->transactionResponse->orderId,
+            $mock->transactionResponse->transactionId
+        );
     }
 
     /**
      * @see PaymentApi::refund()
      * @dataProvider providerMockTransaction
+     *
+     * @param \PayU\Entity\Transaction\TransactionEntity $transaction
      */
     public function testRefund($transaction)
     {
-    	$this->markTestIncomplete();
-
+        $this->markTestSkipped(
+            "PayU Latam doesn't implement REFUND in test environment"
+        );
     	$mock = $this->object->authorizeAndCapture($transaction);
     	$rs   = $this->object->refund(
     		$mock->transactionResponse->orderId,
     		$mock->transactionResponse->transactionId
     	);
+
+        $this->_testTransactionResponse($rs);
     }
 }


### PR DESCRIPTION
Adds VOID and CAPTURE methods.
Requests now are saved in a different property of payment, but are accessed with the same way.

Can you test if any point of sdk was broken after the changes?
